### PR TITLE
Refactor join function to handle non-string elements

### DIFF
--- a/src/data_weaver/main.py
+++ b/src/data_weaver/main.py
@@ -65,7 +65,7 @@ def handle_value(data, source_key, target_key, default=True):
             list: The handled list.
 
         """
-        handled_list, is_default = [get_value_with_default(sub_key)[0] for sub_key in source_key], any(get_value_with_default(sub_key)[1] for sub_key in source_key)
+        handled_list, is_default = [get_value_with_default(sub_key)[0] for sub_key in source_key], all(get_value_with_default(sub_key)[1] for sub_key in source_key)
         if is_default:
             return handled_list
         return transform_value(handled_list, target_key)

--- a/src/data_weaver/transforms.py
+++ b/src/data_weaver/transforms.py
@@ -51,7 +51,8 @@ def split(value: str, delimiter: str = ' ') -> list:
     return value.split(delimiter)
 
 def join(values: list, delimiter: str = ' ') -> str:
-    return delimiter.join(map(str, values))
+    values = [str(value) if value is not None else '' for value in values]
+    return delimiter.join(values)
 
 def lower(value: str | list | dict) -> str:
     def lower_val(val):


### PR DESCRIPTION
### Description
This pull request includes two main changes in the transforms.py and main.py files.

### Changes

1. File transforms.py:

  - Function join:

    - Updated to handle None values by replacing them with empty strings before joining.

    - Before: Used map(str, values).

    - After: Uses list comprehension to replace None:

      ```python
        values = [str(value) if value is not None else '' for value in values]
        return delimiter.join(values)
      ```

2. File main.py:

  - Function handle_value:
    - Changed logic to set is_default to True only if all values are default.
    - Before: Used any(get_value_with_default(sub_key)[1] for sub_key in source_key).
    - After: Uses all(get_value_with_default(sub_key)[1] for sub_key in source_key):
      ```python
        handled_list, is_default = [get_value_with_default(sub_key)[0] for sub_key in source_key], all(get_value_with_default(sub_key)[1] for 
         sub_key in source_key)
      ```